### PR TITLE
enable getting style attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "html-to-vdom": "git+https://github.com/joshski/html-to-vdom.git#expose-comments",
+    "to-style": "^1.3.3",
     "vdom-to-html": "^2.3.1",
     "virtual-dom": "^2.1.1"
   }

--- a/test/domSpec.js
+++ b/test/domSpec.js
@@ -148,7 +148,23 @@ describe('DOM', function() {
   describe('element.getAttribute', function () {
     it('gets the style of an element', function (document) {
       document.body.innerHTML = '<div id="message" style="color:bold">text</div>'
-      assert.equal(document.getElementById('message').getAttribute('style'), 'color:bold')
+      assert.equal(document.getElementById('message').getAttribute('style'), 'color: bold')
+    })
+  })
+
+  describe('element.setAttribute', function () {
+    it('sets the style of an element', function (document) {
+      document.body.innerHTML = '<div id="message">text</div>'
+      document.getElementById('message').setAttribute('style', 'color: bold')
+      assert.equal(document.getElementById('message').getAttribute('style'), 'color: bold')
+    })
+  })
+
+  describe('element.removeAttribute', function () {
+    it('removes the style of an element', function (document) {
+      document.body.innerHTML = '<div id="message" style="color:bold">text</div>'
+      document.getElementById('message').removeAttribute('style')
+      assert.equal(document.getElementById('message').getAttribute('style'), undefined)
     })
   })
   describe('select.options', function () {

--- a/test/domSpec.js
+++ b/test/domSpec.js
@@ -145,6 +145,12 @@ describe('DOM', function() {
     })
   })
 
+  describe('element.getAttribute', function () {
+    it('gets the style of an element', function (document) {
+      document.body.innerHTML = '<div id="message" style="color:bold">text</div>'
+      assert.equal(document.getElementById('message').getAttribute('style'), 'color:bold')
+    })
+  })
   describe('select.options', function () {
     it('has option elements', function (document) {
       document.body.innerHTML = '<select id="select"><option id="one">one</option><option id="two" selected>two</option></select>'

--- a/test/jquerySpec.js
+++ b/test/jquerySpec.js
@@ -312,4 +312,10 @@ describe('jQuery', function() {
       assert.equal($('body').index(), 1)
     })
   })
+  describe('.find()', function () {
+    it('by [style] ', function ($) {
+      $('body').html('<p><a style="color:red">link</a><b>B</b></p>')
+      assert.equal($('[style]').text(), 'link')
+    })
+  })
 })

--- a/welement.js
+++ b/welement.js
@@ -3,6 +3,8 @@ var WText = require('./wtext')
 var VText = require('virtual-dom/vnode/vtext')
 var WComment = require('./wcomment')
 var convert = require('./convert')
+var toStyleString = require('to-style').string
+var toStyleObject = require('to-style').object
 
 function WElement(vnode, parentWNode) {
   if (vnode.type !== 'VirtualNode') throw new Error("vnode must be a VirtualNode")
@@ -185,13 +187,8 @@ WElement.prototype.getAttribute = function(name) {
   } else if (name == 'type') {
     return this.vnode.properties.type
   } else if (name == 'style') {
-    var style = this.vnode.properties.style
-    if (style) {
-      return Object.keys(style).map(key => {
-        return key + ':'+style[key]
-      }).join(';')
-    } else {
-      return undefined
+    if (this.vnode.properties.style) {
+      return toStyleString(this.vnode.properties.style)
     }
   } else {
     return this.vnode.properties.attributes[name]
@@ -202,11 +199,21 @@ WElement.prototype.getAttributeNode = function(name) {
   return new WAttr(this.getAttribute(name))
 }
 
+WElement.prototype.removeAttribute = function(name) {
+  if (name == 'style') {
+    delete this.vnode.properties.style
+  } else {
+    delete this.vnode.properties.attributes[name]
+  }
+}
+
 WElement.prototype.setAttribute = function(name, value) {
   if (name == 'id') {
     this.vnode.properties.id = value
   } else if (name == 'class') {
     this.vnode.properties.className = value
+  } else if (name == 'style') {
+    this.vnode.properties.style = toStyleObject(value)
   } else {
     this.vnode.properties.attributes = this.vnode.properties.attributes || {}
     this.vnode.properties.attributes[name] = value

--- a/welement.js
+++ b/welement.js
@@ -184,6 +184,15 @@ WElement.prototype.getAttribute = function(name) {
     return this.vnode.properties.target
   } else if (name == 'type') {
     return this.vnode.properties.type
+  } else if (name == 'style') {
+    var style = this.vnode.properties.style
+    if (style) {
+      return Object.keys(style).map(key => {
+        return key + ':'+style[key]
+      }).join(';')
+    } else {
+      return undefined
+    }
   } else {
     return this.vnode.properties.attributes[name]
   }


### PR DESCRIPTION
this adds support for `element.getAttribute('style')` which enabled `$('[style]')` in jquery.
we need this.
I am a bit concerned about how we are implementing getAttribute as it is exploding and not in a good way - ideas?