### PR TITLE
default attributes to empty object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
-*.swp
+*.sw?
+*.orig

--- a/test/domSpec.js
+++ b/test/domSpec.js
@@ -146,6 +146,13 @@ describe('DOM', function() {
   })
 
   describe('element.getAttribute', function () {
+    it('gets an attribute when attributes is null', function (document) {
+      var el = document.createElement('div')
+      el.id = 'message'
+      document.body.appendChild(el)
+      assert.equal(document.getElementById('message').getAttribute('notRealAttribute'), null)
+    })
+
     it('gets the style of an element', function (document) {
       document.body.innerHTML = '<div id="message" style="color:bold">text</div>'
       assert.equal(document.getElementById('message').getAttribute('style'), 'color: bold')

--- a/wdocument.js
+++ b/wdocument.js
@@ -62,7 +62,7 @@ WDocument.prototype.createDocumentFragment = function() {
 }
 
 WDocument.prototype.createElement = function(tagName) {
-  return new WElement(h(tagName), this)
+  return new WElement(h(tagName, {attributes: {}}), this)
 }
 
 WDocument.prototype.removeChild = function(child) {


### PR DESCRIPTION
When creating an element using `document.createElement('tagName')` the element would have a null `el.vnode.properties.attributes` value which would cause `el.getAttribute('class')` to fail (null reference),

This change initialises the attributes property when an element is created